### PR TITLE
get only permission bug fixed

### DIFF
--- a/src/Permissions.php
+++ b/src/Permissions.php
@@ -78,7 +78,9 @@ class Permissions
     public function getOnlyPermissionsNames()
     {
         if (!$this->hasCachedPermissions()) {
-            return sort($this->onlyPermissionsNames);
+            sort($this->onlyPermissionsNames);
+
+            return $this->onlyPermissionsNames;
         }
 
         return Cache::get(Constant::CACHE_ONLY_PERMISSIONS);


### PR DESCRIPTION
In permission getOnlyPermissionsNames return bool, it should return array of permission names.